### PR TITLE
Add `offered_since`, fix sorting, enhance price bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ pip3 install marktplaats
 ## Example
 This is an example on how to use the library:
 ```py
+from datetime import datetime, timedelta
+
 from marktplaats import SearchQuery, SortBy, SortOrder
 
 search = SearchQuery("fiets", # Search query
@@ -19,7 +21,8 @@ search = SearchQuery("fiets", # Search query
                      limit=5, # Max listings (page size, max 25)
                      offset=0, # Offset for listings (page * limit)
                      sort_by=SortBy.OPTIMIZED, # DATE, PRICE, LOCATATION, OPTIMIZED
-                     sort_order=SortOrder.ASC) # ASCending or DESCending
+                     sort_order=SortOrder.ASC, # ASCending or DESCending
+                     offered_since=datetime.now() - timedelta(days=7)) # Filter listings since a point in time
 
 listings = search.get_listings()
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -112,13 +112,21 @@ class TestSearchQuery(unittest.TestCase):
                 ]
             }"""
             
-            query = SearchQuery("fiets", price_from=10, price_to=200)
+            query = SearchQuery(
+                "fiets",
+                price_from=10,
+                price_to=200,
+                offered_since=datetime(2024, 12, 31, 14, 10, 0),
+            )
 
             get_request.assert_called_once_with(
                 "https://www.marktplaats.nl/lrp/api/search",
                 params={
-                    "attributeRanges[]":  [
+                    "attributeRanges[]": [
                         "PriceCents:1000:20000",
+                    ],
+                    "attributesByKey[]": [
+                        "offeredSince:1735650600000",
                     ],
                     "limit": "1",
                     "offset": "0",
@@ -127,8 +135,8 @@ class TestSearchQuery(unittest.TestCase):
                     "viewOptions": "list-view",
                     "distanceMeters": "1000000",  # basically unlimited
                     "postcode": "",
-                    "sortBy": SortBy.OPTIMIZED,
-                    "sort_order": SortOrder.ASC,
+                    "sortBy": "OPTIMIZED",
+                    "sortOrder": "INCREASING",
                 },
                 headers={
                     "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.0.0 Safari/537.36",


### PR DESCRIPTION
Hi :wave:
I originally wanted to just add support for the `offeredSince` parameter, but stumbled upon a few glaring issues. I can split this up into multiple pull requests if necessary.

Changes:
* Price bounds will now use `"null"` when a bound is absent (`None`) instead of `"0"` and `"1000000"` as is the behavior of the Marktplaats website itself
* Price bounds are now excluded from the API call when both parameters are omitted
* Changed `sort_order` to `sortOrder`. This seemed to be causing an issue with sorting.
* Use `.value` on the `SortBy` and `SortOrder` enums when passing them to `requests.get`. This seemed to be causing an issue with sorting.
* The newly added `offered_since` parameter will add the `offeredSince` parameter to the API call, to filter on new adverts only.

I am observing some inconsistency with the results; when getting a list of adverts sorted by date, some adverts are missing on some requests, and present on others. This seems to be on Marktplaats' end, and might not even be related to the `offeredSince` parameter. Any idea what this can be?