### PR TITLE
Fix dependencies not being recognized by using `hatch-requirements-txt` instead of `setuptools.dynamic`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,15 +12,16 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+dynamic = ["dependencies"]
 
-[tool.setuptools.dynamic]
-dependencies = {file = ["requirements.txt"]}
+[tool.hatch.metadata.hooks.requirements_txt]
+files = ["requirements.txt"]
 
 [project.urls]
 "Homepage" = "https://github.com/jensjeflensje/marktplaats-py"
 "Bug Tracker" = "https://github.com/jensjeflensje/marktplaats-py/issues"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-requirements-txt"]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
Fixes #8
I have tested it, and it now installs `requests` along with `marktplaats`.