### PR TITLE
Make `Listing` hashable

### DIFF
--- a/marktplaats/models/listing.py
+++ b/marktplaats/models/listing.py
@@ -26,5 +26,8 @@ class Listing:
     def __eq__(self, other):
         return self.id == other.id
 
+    def __hash__(self):
+        return hash(self.id)
+
     def price_as_string(self, euro_sign: bool = True, lang: str = "en") -> str:
         return self.price_type._as_string(self.price, euro_sign, lang)


### PR DESCRIPTION
Accompanying `__eq__` is now `__hash__`. There's no reason why a `Listing` can't be hashable.