### PR TITLE
Implement `__eq__` and `__hash__` for category classes; add `get_l1_categories`, `get_l2_categories`, `get_subcategories`

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -36,7 +36,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.project.outputs.version }}
+          tag_name: v${{ steps.project.outputs.version }}
           release_name: v${{ steps.project.outputs.version }}
           body: New release ${{ steps.project.outputs.version }}
           draft: false

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -25,7 +25,9 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
-      - name: Extract Maven project version
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Extract project version
         run: echo ::set-output name=version::$(grep -m 1 version pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3)
         id: project
       - name: Create Release

--- a/marktplaats/categories.py
+++ b/marktplaats/categories.py
@@ -105,6 +105,15 @@ def get_subcategories(l1_category: L1Category) -> Iterator[L2Category]:
     return (cat for cat in get_l2_categories() if cat.parent == l1_category)
 
 
+def get_l2_categories_by_parent() -> dict[L1Category, list[L2Category]]:
+    categories = {}
+    for category in get_l2_categories():
+        if category.parent not in categories:
+            categories[category.parent] = []
+        categories[category.parent].append(category)
+    return categories
+
+
 _l1_categories_file = (Path(__file__).parent / "l1_categories.json").resolve()
 _l1_categories_raw = LazyWrapper(_l1_categories_file)
 _l2_categories_file = (Path(__file__).parent / "l2_categories.json").resolve()

--- a/marktplaats/categories.py
+++ b/marktplaats/categories.py
@@ -1,5 +1,6 @@
 import json
-from collections.abc import Iterator
+from collections import defaultdict
+from collections.abc import Iterator, Mapping
 
 from pathlib import Path
 
@@ -105,11 +106,9 @@ def get_subcategories(l1_category: L1Category) -> Iterator[L2Category]:
     return (cat for cat in get_l2_categories() if cat.parent == l1_category)
 
 
-def get_l2_categories_by_parent() -> dict[L1Category, list[L2Category]]:
-    categories = {}
+def get_l2_categories_by_parent() -> Mapping[L1Category, list[L2Category]]:
+    categories = defaultdict(list)
     for category in get_l2_categories():
-        if category.parent not in categories:
-            categories[category.parent] = []
         categories[category.parent].append(category)
     return categories
 


### PR DESCRIPTION
* Implemented `__eq__` and `__hash__` for category classes
* Added `get_l1_categories`, `get_l2_categories`, `get_subcategories`, `get_l2_categories_by_parent` to easily get a list of categories or subcategories
* Made `lx_categories` and `lx_categories_file` private; I don't see any reason to use them when these new functions are available, it will only lead to confusion