### PR TITLE
Fix `__eq__` implementations

### DIFF
--- a/marktplaats/categories.py
+++ b/marktplaats/categories.py
@@ -31,6 +31,8 @@ class L1Category:
         return self.name
 
     def __eq__(self, other):
+        if not isinstance(other, L1Category):
+            return NotImplemented
         return self.id == other.id
 
     def __hash__(self):
@@ -63,6 +65,8 @@ class L2Category:
         return self.name
 
     def __eq__(self, other):
+        if not isinstance(other, L2Category):
+            return NotImplemented
         return self.id == other.id
 
     def __hash__(self):

--- a/marktplaats/models/listing.py
+++ b/marktplaats/models/listing.py
@@ -24,6 +24,8 @@ class Listing:
     extended_attributes: list
 
     def __eq__(self, other):
+        if not isinstance(other, Listing):
+            return NotImplemented
         return self.id == other.id
 
     def __hash__(self):


### PR DESCRIPTION
Whoops, I messed up. This caused some annoying crashes when comparing any category or listing to anything else (like `None`) instead of just returning `False`. This addresses that.