### PR TITLE
Misc request changes

### DIFF
--- a/.github/workflows/run_live_tests.yaml
+++ b/.github/workflows/run_live_tests.yaml
@@ -12,6 +12,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install buildtools
-        run: pip install -r requirements.txt
+        run: pip install -r requirements.txt tests/requirements.txt
       - name: Run tests
         run: python -m unittest tests/test_live.py

--- a/.github/workflows/tests_on_pr.yaml
+++ b/.github/workflows/tests_on_pr.yaml
@@ -10,6 +10,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install pip packages
-        run: pip install -r requirements.txt
+        run: pip install -r requirements.txt -r tests/requirements.txt
       - name: Run tests
         run: python -m unittest tests/*.py

--- a/marktplaats/query.py
+++ b/marktplaats/query.py
@@ -142,8 +142,8 @@ class SearchQuery:
 
         try:
             self.body_json = self.response.json()
-        except JSONDecodeError:
-            raise Exception(f"Received invalid (non-json) response:", self.response.text)
+        except JSONDecodeError as err:
+            raise Exception(f"Received invalid (non-json) response:", self.response.text) from err
 
         self._set_query_data()
 

--- a/marktplaats/query.py
+++ b/marktplaats/query.py
@@ -8,7 +8,7 @@ from marktplaats.categories import L2Category
 from marktplaats.config import ISSUE_LINK
 from marktplaats.models import Listing, ListingImage, ListingLocation, ListingSeller
 from marktplaats.models.price_type import PriceType
-from marktplaats.utils import REQUEST_HEADERS
+from marktplaats.utils import REQUEST_HEADERS, MessageObjectException
 
 logger = logging.getLogger(__name__)
 
@@ -28,11 +28,11 @@ MONTH_MAPPING = {
 }
 
 
-class BadStatusCodeError(Exception):
+class BadStatusCodeError(MessageObjectException):
     pass
 
 
-class JSONDecodeError(Exception):
+class JSONDecodeError(MessageObjectException):
     pass
 
 
@@ -145,7 +145,7 @@ class SearchQuery:
 
         # But if it's something else non-200, still fail fast.
         if self.response.status_code != 200:
-            raise BadStatusCodeError(f"Received non-200 status code", self.response)
+            raise BadStatusCodeError(f"Received non-200 status code:", self.response)
 
         try:
             self.body_json = self.response.json()

--- a/marktplaats/utils.py
+++ b/marktplaats/utils.py
@@ -4,3 +4,13 @@ REQUEST_HEADERS = {
     "Sec-Fetch-Mode": "cors",
     "Sec-Fetch-Site": "same-origin",
 }
+
+
+class MessageObjectException(Exception):
+    def __init__(self, msg: str, obj: object):
+        super().__init__(msg, obj)
+        self.msg = msg
+        self.obj = obj
+
+    def __str__(self):
+        return f"{self.msg} {self.obj}"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,1 @@
+requests_mock>=1.12.1

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -8,7 +8,7 @@ import requests_mock
 from marktplaats.categories import category_from_name
 from marktplaats.models import ListingLocation
 
-from marktplaats import SearchQuery, PriceType, BadStatusCodeError
+from marktplaats import SearchQuery, PriceType, BadStatusCodeError, JSONDecodeError
 
 
 class BasicSearchQueryTest(unittest.TestCase):
@@ -229,6 +229,15 @@ class BasicSearchQueryTest(unittest.TestCase):
                 status_code=204,
             )
             with self.assertRaises(BadStatusCodeError):
+                _query = SearchQuery("fiets")
+
+    def test_invalid_json(self):
+        with requests_mock.Mocker() as m:
+            m.get(
+                "https://www.marktplaats.nl/lrp/api/search?limit=1&offset=0&query=fiets&searchInTitleAndDescription=true&viewOptions=list-view&distanceMeters=1000000&postcode=&sortBy=OPTIMIZED&sortOrder=INCREASING",
+                text="this is some invalid JSON",
+            )
+            with self.assertRaises(JSONDecodeError):
                 _query = SearchQuery("fiets")
 
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -15,7 +15,8 @@ class BasicSearchQueryTest(unittest.TestCase):
 
     def test_request(self):
         with patch('requests.get') as get_request:
-            get_request.return_value.text = """{
+            get_request.return_value.status_code = 200
+            get_request.return_value.json.return_value = {
                 "totalResultCount": 100,
                 "listings": [
                     {
@@ -23,7 +24,7 @@ class BasicSearchQueryTest(unittest.TestCase):
                         "title": "Batavus damesfiets 26 inch",
                         "description": "Degelijke batavus damesfiets 26 inch met slot, verlichting en versnellingen.",
                         "categorySpecificDescription": "Degelijke batavus damesfiets 26 inch met slot, verlichting en versnellingen.",
-                        "thinContent": true,
+                        "thinContent": True,
                         "priceInfo": {
                             "priceCents": 7500,
                             "priceType": "FIXED"
@@ -33,9 +34,9 @@ class BasicSearchQueryTest(unittest.TestCase):
                             "countryName": "Nederland",
                             "countryAbbreviation": "NL",
                             "distanceMeters": 1000,
-                            "isBuyerLocation": false,
-                            "onCountryLevel": false,
-                            "abroad": false,
+                            "isBuyerLocation": False,
+                            "onCountryLevel": False,
+                            "abroad": False,
                             "latitude": 51.965397128056,
                             "longitude": 4.6119871732025
                         },
@@ -46,15 +47,15 @@ class BasicSearchQueryTest(unittest.TestCase):
                         "sellerInformation": {
                             "sellerId": 7405065,
                             "sellerName": "Vogel",
-                            "showSoiUrl": true,
-                            "showWebsiteUrl": false,
-                            "isVerified": false
+                            "showSoiUrl": True,
+                            "showWebsiteUrl": False,
+                            "isVerified": False
                         },
                         "categoryId": 447,
                         "priorityProduct": "NONE",
-                        "videoOnVip": false,
-                        "urgencyFeatureActive": false,
-                        "napAvailable": false,
+                        "videoOnVip": False,
+                        "urgencyFeatureActive": False,
+                        "napAvailable": False,
                         "attributes": [
                             {
                                 "key": "condition",
@@ -112,7 +113,7 @@ class BasicSearchQueryTest(unittest.TestCase):
                         "vipUrl": "/v/fietsen-en-brommers/fietsen-dames-damesfietsen/m2064554806-batavus-damesfiets-26-inch"
                     }
                 ]
-            }"""
+            }
             
             query = SearchQuery(
                 "fiets",

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone, date
 from unittest.mock import patch
 
 import requests
+import requests_mock
 
 from marktplaats.categories import category_from_name
 from marktplaats.models import ListingLocation
@@ -208,23 +209,25 @@ class BasicSearchQueryTest(unittest.TestCase):
         self.assertFalse(seller.identification)
         self.assertTrue(seller.phone_number)
 
-    def test_http_error_404(self):
+    def test_http_error_400(self):
         # This should be the same for other 4xx and 5xx errors
 
-        # This is the easiest way to fabricate an actual response object
-        response = requests.get("https://httpstat.us/404")
-
-        with patch('requests.get', return_value=response):
+        with requests_mock.Mocker() as m:
+            m.get(
+                "https://www.marktplaats.nl/lrp/api/search?limit=1&offset=0&query=fiets&searchInTitleAndDescription=true&viewOptions=list-view&distanceMeters=1000000&postcode=&sortBy=OPTIMIZED&sortOrder=INCREASING",
+                status_code=400,
+            )
             with self.assertRaises(requests.HTTPError):
                 _query = SearchQuery("fiets")
 
     def test_http_error_204(self):
         # This should be the same for all other non-200 non-4xx non-5xx errors
 
-        # This is the easiest way to fabricate an actual response object
-        response = requests.get("https://httpstat.us/204")
-
-        with patch('requests.get', return_value=response):
+        with requests_mock.Mocker() as m:
+            m.get(
+                "https://www.marktplaats.nl/lrp/api/search?limit=1&offset=0&query=fiets&searchInTitleAndDescription=true&viewOptions=list-view&distanceMeters=1000000&postcode=&sortBy=OPTIMIZED&sortOrder=INCREASING",
+                status_code=204,
+            )
             with self.assertRaises(BadStatusCodeError):
                 _query = SearchQuery("fiets")
 


### PR DESCRIPTION
Use `response.json()` instead of `json.loads(response.text)`, fail on non-200 status codes and clarify comments about that, throw more informative error on `JSONDecodeError`.

Ref #30 

As soon as I get another invalid response, I'll let you know in #30 to hopefully fix or handle it. But this way I hopefully have enough information to see what's wrong.