### PR TITLE
Allow missing query, throw when query and category are both empty.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta
 
 from marktplaats import SearchQuery, SortBy, SortOrder, Condition, category_from_name
 
-search = SearchQuery("gazelle", # Search query
+search = SearchQuery(query="gazelle", # Search query. Can be left out, but then category must be specified.
                      zip_code="1016LV", # Zip code to base distance from
                      distance=100000, # Max distance from the zip code for listings
                      price_from=0, # Lowest price to search for

--- a/marktplaats/query.py
+++ b/marktplaats/query.py
@@ -88,7 +88,7 @@ class SearchQuery:
         extra_attributes=None,  # EXPERIMENTAL: list of integers, just like Condition
     ):
         if query == "" and category is None:
-            raise TypeError("Invalid arguments: When the query is empty, a category must be specified.")
+            raise ValueError("Invalid arguments: When the query is empty, a category must be specified.")
 
         params = {
             "limit": str(limit),

--- a/marktplaats/query.py
+++ b/marktplaats/query.py
@@ -73,7 +73,7 @@ class SearchQuery:
 
     def __init__(
         self,
-        query,
+        query="",
         zip_code="",
         distance=1000000,  # in meters, basically unlimited
         price_from=None,
@@ -87,6 +87,9 @@ class SearchQuery:
         category=None,
         extra_attributes=None,  # EXPERIMENTAL: list of integers, just like Condition
     ):
+        if query == "" and category is None:
+            raise TypeError("Invalid argument set: When the query is empty, a category must be specified.")
+
         params = {
             "limit": str(limit),
             "offset": str(offset),

--- a/marktplaats/query.py
+++ b/marktplaats/query.py
@@ -88,7 +88,7 @@ class SearchQuery:
         extra_attributes=None,  # EXPERIMENTAL: list of integers, just like Condition
     ):
         if query == "" and category is None:
-            raise TypeError("Invalid argument set: When the query is empty, a category must be specified.")
+            raise TypeError("Invalid arguments: When the query is empty, a category must be specified.")
 
         params = {
             "limit": str(limit),

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -205,6 +205,10 @@ class BasicSearchQueryTest(unittest.TestCase):
         self.assertFalse(seller.identification)
         self.assertTrue(seller.phone_number)
 
+    def test_query_category_valueerror(self):
+        with self.assertRaises(ValueError):
+            _query = SearchQuery(price_to=10)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #30
I also added a default `query=""` here, since it just makes sense to have, especially now that this edge case is taken care of. I have been using `query=""` as a default in marktplaats-notif for a while, and it has always worked fine (except when I left the category empty as well).