### PR TITLE
Fix live test cron workflow

### DIFF
--- a/.github/workflows/run_live_tests.yaml
+++ b/.github/workflows/run_live_tests.yaml
@@ -12,6 +12,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install buildtools
-        run: pip install -r requirements.txt tests/requirements.txt
+        run: pip install -r requirements.txt -r tests/requirements.txt
       - name: Run tests
         run: python -m unittest tests/test_live.py


### PR DESCRIPTION
Whoops, missed a `-r`. The live test cron workflow was failing. This did not apply to the PR workflows.