### PR TITLE
Add typing and miscellaneous fixes

### DIFF
--- a/marktplaats/__init__.py
+++ b/marktplaats/__init__.py
@@ -1,3 +1,24 @@
-from .query import BadStatusCodeError as BadStatusCodeError, JSONDecodeError as JSONDecodeError, SortBy as SortBy, SortOrder as SortOrder, Condition as Condition, SearchQuery as SearchQuery
-from .models import ListingFirstImage as ListingFirstImage, ListingSeller as ListingSeller, ListingLocation as ListingLocation, Listing as Listing, PriceType as PriceType
-from .categories import category_from_name as category_from_name, get_l1_categories as get_l1_categories, get_l2_categories as get_l2_categories, get_subcategories as get_subcategories, get_l2_categories_by_parent as get_l2_categories_by_parent, L1Category as L1Category, L2Category as L2Category
+from .query import (
+    BadStatusCodeError as BadStatusCodeError,
+    JSONDecodeError as JSONDecodeError,
+    SortBy as SortBy,
+    SortOrder as SortOrder,
+    Condition as Condition,
+    SearchQuery as SearchQuery,
+)
+from .models import (
+    ListingFirstImage as ListingFirstImage,
+    ListingSeller as ListingSeller,
+    ListingLocation as ListingLocation,
+    Listing as Listing,
+    PriceType as PriceType,
+)
+from .categories import (
+    category_from_name as category_from_name,
+    get_l1_categories as get_l1_categories,
+    get_l2_categories as get_l2_categories,
+    get_subcategories as get_subcategories,
+    get_l2_categories_by_parent as get_l2_categories_by_parent,
+    L1Category as L1Category,
+    L2Category as L2Category,
+)

--- a/marktplaats/__init__.py
+++ b/marktplaats/__init__.py
@@ -1,2 +1,3 @@
-from .query import *
-from .categories import *
+from .query import BadStatusCodeError as BadStatusCodeError, JSONDecodeError as JSONDecodeError, SortBy as SortBy, SortOrder as SortOrder, Condition as Condition, SearchQuery as SearchQuery
+from .models import ListingFirstImage as ListingFirstImage, ListingSeller as ListingSeller, ListingLocation as ListingLocation, Listing as Listing, PriceType as PriceType
+from .categories import category_from_name as category_from_name, get_l1_categories as get_l1_categories, get_l2_categories as get_l2_categories, get_subcategories as get_subcategories, get_l2_categories_by_parent as get_l2_categories_by_parent, L1Category as L1Category, L2Category as L2Category

--- a/marktplaats/categories.py
+++ b/marktplaats/categories.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import json
-from builtins import _NotImplementedType
 from collections import defaultdict
 from collections.abc import Iterator, Mapping
 
 from pathlib import Path
+from types import NotImplementedType
 
 from typing import Any
 from typing_extensions import Self
@@ -34,7 +34,7 @@ class L1Category:
     def __str__(self) -> str:
         return self.name
 
-    def __eq__(self, other: object) -> _NotImplementedType | bool:
+    def __eq__(self, other: object) -> NotImplementedType | bool:
         if not isinstance(other, L1Category):
             return NotImplemented
         return self.id == other.id
@@ -68,7 +68,7 @@ class L2Category:
     def __str__(self) -> str:
         return self.name
 
-    def __eq__(self, other: object) -> _NotImplementedType | bool:
+    def __eq__(self, other: object) -> NotImplementedType | bool:
         if not isinstance(other, L2Category):
             return NotImplemented
         return self.id == other.id

--- a/marktplaats/categories.py
+++ b/marktplaats/categories.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 import json
+from builtins import _NotImplementedType
 from collections import defaultdict
 from collections.abc import Iterator, Mapping
 
 from pathlib import Path
 
-from typing import Union
+from typing import Any
+from typing_extensions import Self
 
 
 class L1Category:
@@ -13,7 +17,7 @@ class L1Category:
         self.name = name
 
     @classmethod
-    def from_name(cls, name: str):
+    def from_name(cls, name: str) -> Self:
         orig_name = name
         name = name.lower()
         try:
@@ -24,18 +28,18 @@ class L1Category:
         return cls(id_, name)
 
     @classmethod
-    def from_id(cls, id_: int, name: str = "Unknown"):
+    def from_id(cls, id_: int, name: str = "Unknown") -> None:
         cls(id_, name)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> _NotImplementedType | bool:
         if not isinstance(other, L1Category):
             return NotImplemented
         return self.id == other.id
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.id)
 
 
@@ -46,7 +50,7 @@ class L2Category:
         self.parent = parent
 
     @classmethod
-    def from_name(cls, name: str):
+    def from_name(cls, name: str) -> Self:
         orig_name = name
         name = name.lower()
         try:
@@ -58,22 +62,22 @@ class L2Category:
         return cls(id_, name, parent)
 
     @classmethod
-    def from_id(cls, id_: int, parent: L1Category, name: str = "Unknown"):
+    def from_id(cls, id_: int, parent: L1Category, name: str = "Unknown") -> None:
         cls(id_, name, parent)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> _NotImplementedType | bool:
         if not isinstance(other, L2Category):
             return NotImplemented
         return self.id == other.id
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.id)
 
 
-def category_from_name(name: str) -> Union[L1Category, L2Category]:
+def category_from_name(name: str) -> L1Category | L2Category:
     try:
         return L1Category.from_name(name)
     except ValueError:
@@ -83,11 +87,12 @@ def category_from_name(name: str) -> Union[L1Category, L2Category]:
 class LazyWrapper:
     def __init__(self, filename: Path):
         self.filename = filename
-        self._data = None
+        self._data: dict[Any, Any] | None = None
 
-    def get_data(self):
+    def get_data(self) -> dict[Any, Any]:
         if self._data is None:
             self._build_data()
+            assert self._data is not None
         return self._data
 
     def _build_data(self) -> None:

--- a/marktplaats/models/__init__.py
+++ b/marktplaats/models/__init__.py
@@ -2,3 +2,4 @@ from .listing_image import ListingFirstImage as ListingFirstImage
 from .listing_seller import ListingSeller as ListingSeller
 from .listing_location import ListingLocation as ListingLocation
 from .listing import Listing as Listing
+from .price_type import PriceType as PriceType

--- a/marktplaats/models/__init__.py
+++ b/marktplaats/models/__init__.py
@@ -1,4 +1,4 @@
-from .listing_image import ListingFirstImage
-from .listing_seller import ListingSeller
-from .listing_location import ListingLocation
-from .listing import Listing
+from .listing_image import ListingFirstImage as ListingFirstImage
+from .listing_seller import ListingSeller as ListingSeller
+from .listing_location import ListingLocation as ListingLocation
+from .listing import Listing as Listing

--- a/marktplaats/models/listing.py
+++ b/marktplaats/models/listing.py
@@ -1,6 +1,6 @@
 import warnings
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date
 from typing import Optional
 
 from marktplaats.models import ListingSeller, ListingFirstImage
@@ -14,7 +14,7 @@ class Listing:
     id: str
     title: str
     description: str
-    date: Optional[datetime]
+    date: Optional[date]
     seller: ListingSeller
     location: ListingLocation
     price: float

--- a/marktplaats/models/listing.py
+++ b/marktplaats/models/listing.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import warnings
 from dataclasses import dataclass
 from datetime import date
-from typing import Optional
+from types import NotImplementedType
+from typing import Any
 
 from marktplaats.models import ListingSeller, ListingFirstImage
 from marktplaats.models.listing_image import fetch_listing_images
@@ -14,7 +17,7 @@ class Listing:
     id: str
     title: str
     description: str
-    date: Optional[date]
+    date: date | None
     seller: ListingSeller
     location: ListingLocation
     price: float
@@ -22,8 +25,8 @@ class Listing:
     link: str
     _images: list[ListingFirstImage]
     category_id: int
-    attributes: list
-    extended_attributes: list
+    attributes: list[dict[str, Any]]
+    extended_attributes: list[dict[str, Any]]
 
     @property
     def images(self) -> list[ListingFirstImage]:
@@ -45,12 +48,12 @@ class Listing:
     def get_images(self) -> list[str]:
         return fetch_listing_images(self.id)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> NotImplementedType | bool:
         if not isinstance(other, Listing):
             return NotImplemented
         return self.id == other.id
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.id)
 
     def price_as_string(self, euro_sign: bool = True, lang: str = "en") -> str:

--- a/marktplaats/models/listing_image.py
+++ b/marktplaats/models/listing_image.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 import json
+from typing import Any
 
 import requests
 from bs4 import BeautifulSoup
+from typing_extensions import Self
 
 from marktplaats.utils import REQUEST_HEADERS
 
@@ -19,7 +21,7 @@ class ListingFirstImage:
     extra_large: str
 
     @classmethod
-    def parse(cls, data):
+    def parse(cls, data: list[dict[str, Any]]) -> list[Self]:
         if data is None:
             return []
         images = []

--- a/marktplaats/models/listing_location.py
+++ b/marktplaats/models/listing_location.py
@@ -8,7 +8,7 @@ from typing_extensions import Self
 
 @dataclass
 class ListingLocation:
-    city: str
+    city: str | None
     country: str | None
     country_short: str | None
     latitude: float
@@ -21,8 +21,8 @@ class ListingLocation:
             data.get("cityName"),
             data.get("countryName"),
             data.get("countryAbbrevation"),
-            data.get("latitude"),
-            data.get("longitude"),
+            data["latitude"],
+            data["longitude"],
             None if data.get("distanceMeters") == -1000 else data.get("distanceMeters"),
         )
 

--- a/marktplaats/models/listing_location.py
+++ b/marktplaats/models/listing_location.py
@@ -1,18 +1,22 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any
+
+from typing_extensions import Self
 
 
 @dataclass
 class ListingLocation:
     city: str
-    country: Optional[str]
-    country_short: Optional[str]
+    country: str | None
+    country_short: str | None
     latitude: float
     longitude: float
-    distance: Optional[int]
+    distance: int | None
 
     @classmethod
-    def parse(cls, data):
+    def parse(cls, data: dict[str, Any]) -> Self:
         return cls(
             data.get("cityName"),
             data.get("countryName"),

--- a/marktplaats/models/listing_location.py
+++ b/marktplaats/models/listing_location.py
@@ -11,8 +11,8 @@ class ListingLocation:
     city: str | None
     country: str | None
     country_short: str | None
-    latitude: float
-    longitude: float
+    latitude: float | None
+    longitude: float | None
     distance: int | None
 
     @classmethod
@@ -21,8 +21,8 @@ class ListingLocation:
             data.get("cityName"),
             data.get("countryName"),
             data.get("countryAbbrevation"),
-            data["latitude"],
-            data["longitude"],
+            data["latitude"] if data["latitude"] != 0 else None,
+            data["longitude"] if data["longitude"] != 0 else None,
             None if data.get("distanceMeters") == -1000 else data.get("distanceMeters"),
         )
 

--- a/marktplaats/models/listing_seller.py
+++ b/marktplaats/models/listing_seller.py
@@ -1,7 +1,9 @@
 import json
 from dataclasses import dataclass
+from typing import Any
 
 import requests
+from typing_extensions import Self
 
 from marktplaats.utils import REQUEST_HEADERS
 
@@ -25,14 +27,14 @@ class ListingSeller:
     is_verified: bool
 
     @classmethod
-    def parse(cls, data):
+    def parse(cls, data: dict[str, Any]) -> Self:
         return cls(
             data["sellerId"],
             data["sellerName"],
             data["isVerified"],
         )
 
-    def get_seller(self):
+    def get_seller(self) -> Seller:
         request = requests.get(
             f"https://www.marktplaats.nl/v/api/seller-profile/{self.id}",
             # Some headers to make the request look legit

--- a/marktplaats/utils.py
+++ b/marktplaats/utils.py
@@ -12,5 +12,5 @@ class MessageObjectException(Exception):
         self.msg = msg
         self.obj = obj
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.msg} {self.obj}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "A small Python package to request listings from marktplaats.nl"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.28.2
 BeautifulSoup4==4.13.4
+typing-extensions>=4.13.2

--- a/scripts/gen_categories_readme.py
+++ b/scripts/gen_categories_readme.py
@@ -4,10 +4,10 @@ import json
 
 def main():
     try:
-        with open("marktplaats/l1_categories.json", "r") as l1, \
-                open("marktplaats/l2_categories.json", "r") as l2:
-            l1_categories = json.loads(l1.read())
-            l2_categories = json.loads(l2.read())
+        with open("marktplaats/l1_categories.json", "r") as l1_file, \
+                open("marktplaats/l2_categories.json", "r") as l2_file:
+            l1_categories = json.loads(l1_file.read())
+            l2_categories = json.loads(l2_file.read())
     except OSError:
         print("Category files not found! Are you executing this script from the project root?")
         return

--- a/scripts/gen_categories_readme.py
+++ b/scripts/gen_categories_readme.py
@@ -2,7 +2,7 @@
 import json
 
 
-def main():
+def main() -> None:
     try:
         with open("marktplaats/l1_categories.json", "r") as l1_file, \
                 open("marktplaats/l2_categories.json", "r") as l2_file:

--- a/scripts/scrape_categories.py
+++ b/scripts/scrape_categories.py
@@ -17,17 +17,20 @@ url = "https://www.marktplaats.nl/"
 soup = parse(url)
 print(f"(url: {url}) ", end="", flush=True)
 select = soup.find("select", {"id": "categoryId"})
+assert isinstance(select, Tag)
 for option in select.children:
     assert isinstance(option, Tag)
+    value = option["value"]
+    assert isinstance(value, str)
     if (
         # "Kies categorie:"
         option.get("disabled") is not None
         # "Alle categorieën…"
-        or option["value"] == "0"
+        or value == "0"
     ):
         continue
     l1_categories[option.text.lower()] = {
-        "id": int(option["value"]),
+        "id": int(value),
         "name": option.text,
     }
 
@@ -54,19 +57,22 @@ for l1_category in l1_categories.values():
     soup = parse(url)
     print(f"(url: {url}) ", end="", flush=True)
     select = soup.find("select", {"id": "categoryId"})
+    assert isinstance(select, Tag)
     for option in select.children:
         assert isinstance(option, Tag)
+        value = option["value"]
+        assert isinstance(value, str)
         if (
             # "Kies categorie:"
             option.get("disabled") is not None
             # "Alle categorieën…"
             or option["value"] == "0"
             # The L1 category itself
-            or int(option["value"]) == l1_category["id"]
+            or int(value) == l1_category["id"]
         ):
             continue
         l2_categories[option.text.lower()] = {
-            "id": int(option["value"]),
+            "id": int(value),
             "name": option.text,
             "parent": l1_category["name"],
         }

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -11,7 +11,7 @@ class ImageFetchTest(unittest.TestCase):
     Basic tests to test image scraping.
     """
 
-    def test_parse_images(self):
+    def test_parse_images(self) -> None:
         dir_path = os.path.dirname(os.path.realpath(__file__))
         with open(os.path.join(dir_path, 'mock/image_response.html'), 'r') as file:
             mock_response = file.read()

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -40,6 +40,7 @@ class LiveSearchQueryTest(unittest.TestCase):
 
             # the date object
             self.assertIsInstance(listing.date, date)
+            assert isinstance(listing.date, date)  # for the type checker
             if check_time:
                 # should be greater or equal to what we queried for
                 self.assertGreaterEqual(listing.date, datetime.now().date() - timedelta(days=7))

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -12,7 +12,7 @@ class LiveSearchQueryTest(unittest.TestCase):
     haven't deployed breaking changes.
     """
 
-    def _validate_response(self, search, check_time: bool = False):
+    def _validate_response(self, search: SearchQuery, check_time: bool = False) -> None:
         listings = search.get_listings()
 
         for listing in listings:
@@ -62,7 +62,7 @@ class LiveSearchQueryTest(unittest.TestCase):
                 self.assertIsInstance(image.large, str)
                 self.assertIsInstance(image.extra_large, str)
 
-    def test_request(self):
+    def test_request(self) -> None:
         search = SearchQuery("fiets",
                              zip_code="1016LV",
                              distance=100000,
@@ -78,7 +78,7 @@ class LiveSearchQueryTest(unittest.TestCase):
         self._validate_response(search, check_time=True)
 
 
-    def test_request_with_condition(self):
+    def test_request_with_condition(self) -> None:
         search = SearchQuery("schijf",
                              zip_code="1016LV",
                              distance=100000,

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -16,7 +16,7 @@ class BasicSearchQueryTest(unittest.TestCase):
     Basic tests to test search query functionality.
     """
 
-    def test_request(self):
+    def test_request(self) -> None:
         with patch('requests.get') as get_request:
             get_request.return_value.status_code = 200
             get_request.return_value.json.return_value = {
@@ -209,7 +209,7 @@ class BasicSearchQueryTest(unittest.TestCase):
         self.assertFalse(seller.identification)
         self.assertTrue(seller.phone_number)
 
-    def test_http_error_400(self):
+    def test_http_error_400(self) -> None:
         # This should be the same for other 4xx and 5xx errors
 
         with requests_mock.Mocker() as m:
@@ -220,7 +220,7 @@ class BasicSearchQueryTest(unittest.TestCase):
             with self.assertRaises(requests.HTTPError):
                 _query = SearchQuery("fiets")
 
-    def test_http_error_204(self):
+    def test_http_error_204(self) -> None:
         # This should be the same for all other non-200 non-4xx non-5xx errors
 
         with requests_mock.Mocker() as m:
@@ -231,7 +231,7 @@ class BasicSearchQueryTest(unittest.TestCase):
             with self.assertRaises(BadStatusCodeError):
                 _query = SearchQuery("fiets")
 
-    def test_invalid_json(self):
+    def test_invalid_json(self) -> None:
         with requests_mock.Mocker() as m:
             m.get(
                 "https://www.marktplaats.nl/lrp/api/search?limit=1&offset=0&query=fiets&searchInTitleAndDescription=true&viewOptions=list-view&distanceMeters=1000000&postcode=&sortBy=OPTIMIZED&sortOrder=INCREASING",
@@ -240,7 +240,7 @@ class BasicSearchQueryTest(unittest.TestCase):
             with self.assertRaises(JSONDecodeError):
                 _query = SearchQuery("fiets")
 
-    def test_query_category_valueerror(self):
+    def test_query_category_valueerror(self) -> None:
         with self.assertRaises(ValueError):
             _query = SearchQuery(price_to=10)
 


### PR DESCRIPTION
* `mypy --strict .` passes now!
* Added py.typed
* Made exports explicit
* Simplified some types (e.g. `Optional` and `Union`)
* Changed `Listing.date` from `datetime | None` to `date | None` (because that's what it is)
* Made `ListingLocation.city` `| None` because it can be sometimes
* Made `ListingLocation.{latitude,longitude}` `| None` and transform `0` to `None`
* Move `_replace_dutch_months` and `_parse_date` out of the `SearchQuery` class