### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# MacOS finder creates this file sometimes
+.DS_Store
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
`.DS_Store` is now missing. Do you still need it? What is that for?
`dist.sh` is now missing. What is that for? You can also just commit it to the repo; is there a reason to keep it only locally?