### PR TITLE
Make some function's arguments keyword-only (BREAKING CHANGE)

### DIFF
--- a/marktplaats/models/listing.py
+++ b/marktplaats/models/listing.py
@@ -63,7 +63,8 @@ class Listing:  # type: ignore[misc] # this will be removed when explicit-any is
 
     def price_as_string(
         self,
-        euro_sign: bool = True,  # noqa: FBT001, FBT002 TODO: consider making the arguments keyword-only (self, *, euro_sign...)
+        *,
+        euro_sign: bool = True,
         lang: str = "en",
     ) -> str:
         return self.price_type._as_string(  # noqa: SLF001 private member access

--- a/marktplaats/query.py
+++ b/marktplaats/query.py
@@ -118,9 +118,10 @@ class SearchQuery:
     Raises a requests.HTTPError if the request fails.
     """
 
-    def __init__(  # noqa: PLR0917, PLR0913 TODO: consider making the arguments keyword-only (self, *, query...)
+    def __init__(  # noqa: PLR0913 too many arguments
         self,
         query: str = "",
+        *,
         zip_code: str = "",
         distance: int = 1000000,  # in meters, basically unlimited
         price_from: int | None = None,


### PR DESCRIPTION
This is a breaking change, but really worth it. This only forces user code to follow best practices (using keyword arguments if positional arguments are unclear), and thus only breaks their code if they were not following best practices.