### PR TITLE
Update mypy and ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,14 +36,14 @@ repos:
       - id: enforce-https
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.11
+    rev: v0.11.12
     hooks:
       - id: ruff-check
         args: [ "--fix" ]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.16.0
     hooks:
       - id: mypy
         pass_filenames: false # Check all files to be thorough

--- a/marktplaats/models/listing.py
+++ b/marktplaats/models/listing.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class Listing:  # type: ignore[misc] # this will be removed when explicit-any is enabled
+class Listing:
     id: str
     title: str
     description: str

--- a/marktplaats/models/listing_location.py
+++ b/marktplaats/models/listing_location.py
@@ -16,7 +16,7 @@ class ListingLocation:
     distance: int | None
 
     @classmethod
-    def parse(cls, data: dict[str, Any]) -> Self:  # type: ignore[misc] # this will be removed when explicit-any is enabled
+    def parse(cls, data: dict[str, Any]) -> Self:
         return cls(
             data.get("cityName"),
             data.get("countryName"),

--- a/marktplaats/models/listing_seller.py
+++ b/marktplaats/models/listing_seller.py
@@ -28,7 +28,7 @@ class ListingSeller:
     is_verified: bool
 
     @classmethod
-    def parse(cls, data: dict[str, Any]) -> Self:  # type: ignore[misc] # this will be removed when explicit-any is enabled
+    def parse(cls, data: dict[str, Any]) -> Self:
         return cls(
             data["sellerId"],
             data["sellerName"],


### PR DESCRIPTION
Coincidence that this happens the first auto-update... Mypy's 1.16 release brought a change to the `Type of decorated function contains type "Any"` error. The `type[ignore]`s are not needed anymore, and are thus errors

Closes #46