### PR TITLE
Add uv to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     schedule:
       interval: "weekly"
 
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This will update `uv.lock` automatically, as the `pip` ecosystem in dependabot only updates pinned requirements from pyproject.toml (which we currently have none). This will make sure the lockfile (and in turn our and CI's environments) stay updated.