### PR TITLE
Remove Renovate pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,13 +68,3 @@ repos:
         args: ["--verbose"]
       - id: check-dependabot
         args: ["--verbose"]
-
-  - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 41.17.2
-    hooks:
-      - id: renovate-config-validator
-        args: [--strict]
-
-ci:
-  skip:
-    - renovate-config-validator


### PR DESCRIPTION
Sorry for ever adding these, these are VERY VERY slow to install, VERY slow to run, can't even run in CI, and have never seen any use.