### PR TITLE
Fix update-categories workflow

### DIFF
--- a/.github/workflows/update-categories.yml
+++ b/.github/workflows/update-categories.yml
@@ -21,10 +21,10 @@ jobs:
           enable-cache: true
 
       - name: Run update_categories.py
-        run: uv run python scripts/update_categories.py
+        run: uv run python -m scripts.update_categories
 
       - name: Run gen_categories_readme.py
-        run: uv run python scripts/gen_categories_readme.py
+        run: uv run python -m scripts.gen_categories_readme
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7


### PR DESCRIPTION
Not the most elegant solution. Using `-m` puts `.` in the `sys.path`.
I tried using `import scrape_categories` (since using `python scripts/a` puts `scripts` in the `sys.path`), but `mypy` doesn't have that in the path.
Open to ideas