### PR TITLE
chore(pyproject): remove deprecated license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ authors = [
 ]
 requires-python = ">=3.10"
 classifiers = [
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: Dutch",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
These were deprecated in [PEP 639](https://peps.python.org/pep-0639/#deprecate-license-classifiers)

Committed via https://github.com/asottile/all-repos