### PR TITLE
fix: use repr conversion in language error

### DIFF
--- a/src/marktplaats/models/price_type.py
+++ b/src/marktplaats/models/price_type.py
@@ -37,7 +37,7 @@ class PriceType(Enum):
         lang: str,
     ) -> str:
         if lang not in {"en", "nl"}:
-            msg = f"{lang:r} not in supported languages (nl, en)"
+            msg = f"{lang!r} not in supported languages (nl, en)"
             raise ValueError(msg)
 
         if self == PriceType.FREE:


### PR DESCRIPTION
Using an unsupported language currently raises `Unknown format code 'r' for object of type 'str'` instead of the expected error message.

This happens because `:` starts a format spec, as in `:d`. There is no `:r`, though. We want the `!r` conversion instead.