### PR TITLE
docs: correct required Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # marktplaats-py
-A small Python package to request listings from marktplaats.nl. It supports python 3.9+.
+A small Python package to request listings from marktplaats.nl. It supports python 3.10+.
 
 ## Installing
 ```shell


### PR DESCRIPTION
The version required in `README.md` currently differs from the one required in `pyproject.toml`.