### PR TITLE
feat: support distance in kilometers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ from marktplaats import Condition, SearchQuery, SortBy, SortOrder, category_from
 search = SearchQuery(
     query="gazelle",  # Search query. Can be left out, but then category must be specified.
     zip_code="1016LV",  # Zip code to base distance from
-    distance=100000,  # Max distance from the zip code for listings
+    distance_km=100,  # Max distance in kilometers from the zip code for listings
     price_from=0,  # Lowest price to search for
     price_to=100,  # Highest price to search for
     limit=5,  # Max listings (page size, max 100)

--- a/src/marktplaats/models/listing_location.py
+++ b/src/marktplaats/models/listing_location.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -17,7 +18,16 @@ class ListingLocation:
     country_short: str | None
     latitude: float | None
     longitude: float | None
-    distance: int | None
+    distance_km: int | None
+
+    @property
+    def distance(self) -> int | None:
+        warnings.warn(
+            "ListingLocation.distance is deprecated. Use distance_km instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.distance_km * 1000 if self.distance_km is not None else None
 
     @classmethod
     def parse(cls, data: Location) -> Self:
@@ -27,5 +37,7 @@ class ListingLocation:
             data.get("countryAbbreviation"),
             data["latitude"] if data["latitude"] != 0 else None,
             data["longitude"] if data["longitude"] != 0 else None,
-            data.get("distanceMeters") if data.get("distanceMeters") != -1000 else None,  # noqa: PLR2004 magic value
+            data.get("distanceMeters") // 1000
+            if data.get("distanceMeters") != -1000  # noqa: PLR2004 magic value
+            else None,
         )

--- a/src/marktplaats/query.py
+++ b/src/marktplaats/query.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from datetime import date, datetime, timedelta
 from enum import Enum
 from typing import TYPE_CHECKING, TypedDict
@@ -145,12 +146,13 @@ class SearchQuery:
     Raises a requests.HTTPError if the request fails.
     """
 
-    def __init__(  # noqa: PLR0913 too many arguments
+    def __init__(  # noqa: PLR0913, C901 too many arguments, too complex
         self,
         query: str = "",
         *,
         zip_code: str = "",
-        distance: int = 1000000,  # in meters, basically unlimited
+        distance: int | None = None,  # In meters, deprecated
+        distance_km: int | None = None,  # In kilometers
         price_from: int | None = None,
         price_to: int | None = None,
         limit: int = 1,
@@ -170,13 +172,27 @@ class SearchQuery:
             )
             raise ValueError(msg)
 
+        if distance is not None:
+            warnings.warn(
+                "distance is deprecated. Use distance_km instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+        distance_meters = (
+            distance_km * 1000
+            if distance_km is not None
+            else distance
+            if distance is not None
+            else 1_000_000  # Basically unlimited
+        )
+
         params: Params = {
             "limit": str(limit),
             "offset": str(offset),
             "query": str(query),
             "searchInTitleAndDescription": "true",
             "viewOptions": "list-view",
-            "distanceMeters": str(distance),
+            "distanceMeters": str(distance_meters),
             "postcode": zip_code,
             "sortBy": sort_by.value,
             "sortOrder": sort_order.value,

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -79,6 +79,14 @@ def _validate_response(search: SearchQuery, check_time: bool = False) -> None:
             images = listing.get_images()
             assert len(images) >= 1
 
+    # Marktplaats currently returns distanceMeters in whole kilometers, which is
+    # why this library exposes distance_km. The following fails if Marktplaats
+    # ever increases the precision, so we can reconsider that API.
+    for listing in search.body_json["listings"]:
+        assert listing["location"]["distanceMeters"] % 1000 == 0, (
+            "Sub-kilometer precision detected"
+        )
+
 
 def test_request() -> None:
     search = SearchQuery(

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -84,7 +84,7 @@ def test_request() -> None:
     search = SearchQuery(
         "fiets",
         zip_code="1016LV",
-        distance=100000,
+        distance_km=100,
         price_from=0,
         price_to=100,
         limit=5,
@@ -102,7 +102,7 @@ def test_request_with_condition() -> None:
     search = SearchQuery(
         "schijf",
         zip_code="1016LV",
-        distance=100000,
+        distance_km=100,
         price_from=0,
         price_to=100,
         offered_since=datetime.now() - timedelta(days=7),


### PR DESCRIPTION
This avoids very large numbers in meters.

Marktplaats uses kilometers on their frontend (e.g. `< 3 km`) and appears to use kilometer precision internally (all their values end in `000`).

Not a breaking change as `distance` is still supported but now emits a warning and can be removed in a future release.