### PR TITLE
feat: make user agent configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ search = SearchQuery(
     offered_since=datetime.now() - timedelta(days=7),  # Filter listings since a point in time
     category=category_from_name("Fietsen en Brommers"),  # Filter in specific category (L1) or subcategory (L2)
     user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 ...",  # Optional; identify your app
-    timeout=15,  # Optional; timeout for HTTP requests in seconds
 )
 
 listings = search.get_listings()

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ search = SearchQuery(
     condition=Condition.NEW,  # NEW, AS_GOOD_AS_NEW, USED or category-specific
     offered_since=datetime.now() - timedelta(days=7),  # Filter listings since a point in time
     category=category_from_name("Fietsen en Brommers"),  # Filter in specific category (L1) or subcategory (L2)
+    user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 ...",  # Optional; identify your app
+    timeout=15,  # Optional; timeout for HTTP requests in seconds
 )
 
 listings = search.get_listings()

--- a/src/marktplaats/config.py
+++ b/src/marktplaats/config.py
@@ -1,4 +1,12 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 
 ISSUE_LINK = "https://github.com/jensjeflensje/marktplaats-py/issues"
+
+
+@dataclass
+class HttpOptions:
+    user_agent: str
+    timeout: int

--- a/src/marktplaats/config.py
+++ b/src/marktplaats/config.py
@@ -1,12 +1,4 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 
 ISSUE_LINK = "https://github.com/jensjeflensje/marktplaats-py/issues"
-
-
-@dataclass
-class HttpOptions:
-    user_agent: str
-    timeout: int

--- a/src/marktplaats/models/listing.py
+++ b/src/marktplaats/models/listing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from marktplaats.models.listing_image import ListingFirstImage, fetch_listing_images
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from types import NotImplementedType
 
     from marktplaats.api_types import Attribute
+    from marktplaats.config import HttpOptions
     from marktplaats.models.listing_location import ListingLocation
     from marktplaats.models.listing_seller import ListingSeller
     from marktplaats.models.price_type import PriceType
@@ -32,6 +33,7 @@ class Listing:
     category_id: int
     attributes: list[Attribute]
     extended_attributes: list[Attribute]
+    http_options: HttpOptions = field(repr=False)
 
     @property
     def images(self) -> list[ListingFirstImage]:
@@ -52,7 +54,7 @@ class Listing:
             return None
 
     def get_images(self) -> list[str]:
-        return fetch_listing_images(self.id)
+        return fetch_listing_images(self.id, self.http_options)
 
     def __eq__(self, other: object) -> NotImplementedType | bool:
         if not isinstance(other, Listing):

--- a/src/marktplaats/models/listing.py
+++ b/src/marktplaats/models/listing.py
@@ -11,8 +11,9 @@ if TYPE_CHECKING:
     from datetime import date
     from types import NotImplementedType
 
+    from requests import Session  # noqa: TID251 - Only used for type hinting.
+
     from marktplaats.api_types import Attribute
-    from marktplaats.config import HttpOptions
     from marktplaats.models.listing_location import ListingLocation
     from marktplaats.models.listing_seller import ListingSeller
     from marktplaats.models.price_type import PriceType
@@ -33,7 +34,7 @@ class Listing:
     category_id: int
     attributes: list[Attribute]
     extended_attributes: list[Attribute]
-    http_options: HttpOptions = field(repr=False)
+    _session: Session = field(repr=False)
 
     @property
     def images(self) -> list[ListingFirstImage]:
@@ -54,7 +55,7 @@ class Listing:
             return None
 
     def get_images(self) -> list[str]:
-        return fetch_listing_images(self.id, self.http_options)
+        return fetch_listing_images(self.id, self._session)
 
     def __eq__(self, other: object) -> NotImplementedType | bool:
         if not isinstance(other, Listing):

--- a/src/marktplaats/models/listing_image.py
+++ b/src/marktplaats/models/listing_image.py
@@ -12,6 +12,7 @@ from marktplaats.utils import get_request
 
 if TYPE_CHECKING:
     from marktplaats.api_types import Picture
+    from marktplaats.config import HttpOptions
 
 
 @dataclass
@@ -42,7 +43,7 @@ class ListingFirstImage:
         ]
 
 
-def fetch_listing_images(listing_id: str) -> list[str]:
+def fetch_listing_images(listing_id: str, http_options: HttpOptions) -> list[str]:
     """
     Return a list of image URLs for a given listing.
 
@@ -50,7 +51,7 @@ def fetch_listing_images(listing_id: str) -> list[str]:
     :param listing_id: The listing ID to get images for.
     :return: A list of image URLs (https).
     """  # noqa: DOC201 TODO: all the docstrings are a bit inconsistent
-    r = get_request(f"https://link.marktplaats.nl/{listing_id}")
+    r = get_request(f"https://link.marktplaats.nl/{listing_id}", http_options)
     r.raise_for_status()  # raises so we can stop the fetching on a higher level
 
     soup = BeautifulSoup(r.text, "html.parser")

--- a/src/marktplaats/models/listing_image.py
+++ b/src/marktplaats/models/listing_image.py
@@ -11,8 +11,9 @@ from marktplaats.utils import get_request
 
 
 if TYPE_CHECKING:
+    from requests import Session  # noqa: TID251 - Only used for type hinting.
+
     from marktplaats.api_types import Picture
-    from marktplaats.config import HttpOptions
 
 
 @dataclass
@@ -43,7 +44,7 @@ class ListingFirstImage:
         ]
 
 
-def fetch_listing_images(listing_id: str, http_options: HttpOptions) -> list[str]:
+def fetch_listing_images(listing_id: str, session: Session) -> list[str]:
     """
     Return a list of image URLs for a given listing.
 
@@ -51,7 +52,7 @@ def fetch_listing_images(listing_id: str, http_options: HttpOptions) -> list[str
     :param listing_id: The listing ID to get images for.
     :return: A list of image URLs (https).
     """  # noqa: DOC201 TODO: all the docstrings are a bit inconsistent
-    r = get_request(f"https://link.marktplaats.nl/{listing_id}", http_options)
+    r = get_request(f"https://link.marktplaats.nl/{listing_id}", session)
     r.raise_for_status()  # raises so we can stop the fetching on a higher level
 
     soup = BeautifulSoup(r.text, "html.parser")

--- a/src/marktplaats/models/listing_seller.py
+++ b/src/marktplaats/models/listing_seller.py
@@ -10,8 +10,9 @@ from marktplaats.utils import get_request
 
 
 if TYPE_CHECKING:
+    from requests import Session  # noqa: TID251 - Only used for type hinting.
+
     from marktplaats.api_types import Review, SellerInformation
-    from marktplaats.config import HttpOptions
 
 
 @dataclass
@@ -31,21 +32,21 @@ class ListingSeller:
     id: int
     name: str
     is_verified: bool
-    http_options: HttpOptions = field(repr=False, compare=False)
+    _session: Session = field(repr=False, compare=False)
 
     @classmethod
-    def parse(cls, data: SellerInformation, http_options: HttpOptions) -> Self:
+    def parse(cls, data: SellerInformation, session: Session) -> Self:
         return cls(
             data["sellerId"],
             data["sellerName"],
             data["isVerified"],
-            http_options,
+            session,
         )
 
     def get_seller(self) -> Seller:
         request = get_request(
             f"https://www.marktplaats.nl/v/api/seller-profile/{self.id}",
-            self.http_options,
+            self._session,
         )
 
         body = request.text

--- a/src/marktplaats/models/listing_seller.py
+++ b/src/marktplaats/models/listing_seller.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from typing_extensions import Self
@@ -11,6 +11,7 @@ from marktplaats.utils import get_request
 
 if TYPE_CHECKING:
     from marktplaats.api_types import Review, SellerInformation
+    from marktplaats.config import HttpOptions
 
 
 @dataclass
@@ -30,18 +31,21 @@ class ListingSeller:
     id: int
     name: str
     is_verified: bool
+    http_options: HttpOptions = field(repr=False, compare=False)
 
     @classmethod
-    def parse(cls, data: SellerInformation) -> Self:
+    def parse(cls, data: SellerInformation, http_options: HttpOptions) -> Self:
         return cls(
             data["sellerId"],
             data["sellerName"],
             data["isVerified"],
+            http_options,
         )
 
     def get_seller(self) -> Seller:
         request = get_request(
-            f"https://www.marktplaats.nl/v/api/seller-profile/{self.id}"
+            f"https://www.marktplaats.nl/v/api/seller-profile/{self.id}",
+            self.http_options,
         )
 
         body = request.text

--- a/src/marktplaats/query.py
+++ b/src/marktplaats/query.py
@@ -11,7 +11,7 @@ from requests.exceptions import (  # noqa: TID251 Not doing any requests
 from typing_extensions import NotRequired
 
 from marktplaats.categories import L1Category, L2Category
-from marktplaats.config import ISSUE_LINK
+from marktplaats.config import ISSUE_LINK, HttpOptions
 from marktplaats.models import (
     Listing,
     ListingFirstImage,
@@ -162,7 +162,14 @@ class SearchQuery:
         category: L1Category | L2Category | None = None,
         extra_attributes: Iterable[int]
         | None = None,  # EXPERIMENTAL: list of integers, just like Condition
+        user_agent: str = (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/101.0.0.0 Safari/537.36"
+        ),
+        timeout: int = 15,
     ) -> None:
+        self.http_options = HttpOptions(user_agent=user_agent, timeout=timeout)
+
         if not query and category is None:
             msg = (
                 "Invalid arguments: When the query is empty, "
@@ -213,6 +220,7 @@ class SearchQuery:
 
         self.response = get_request(
             "https://www.marktplaats.nl/lrp/api/search",
+            self.http_options,
             params=params,
         )
 
@@ -279,7 +287,7 @@ class SearchQuery:
                 listing["title"],
                 listing["description"],
                 listing_time,
-                ListingSeller.parse(listing["sellerInformation"]),
+                ListingSeller.parse(listing["sellerInformation"], self.http_options),
                 ListingLocation.parse(listing["location"]),
                 listing["priceInfo"]["priceCents"] / 100,
                 price_type,
@@ -288,6 +296,7 @@ class SearchQuery:
                 listing["categoryId"],
                 listing.get("attributes", []),
                 listing.get("extendedAttributes", []),
+                self.http_options,
             )
             listings.append(listing_obj)
         return listings

--- a/src/marktplaats/query.py
+++ b/src/marktplaats/query.py
@@ -5,13 +5,14 @@ from datetime import date, datetime, timedelta
 from enum import Enum
 from typing import TYPE_CHECKING, TypedDict
 
+from requests import Session  # noqa: TID251 - Constructing a session.
 from requests.exceptions import (  # noqa: TID251 Not doing any requests
     JSONDecodeError as requests_JSONDecodeError,
 )
 from typing_extensions import NotRequired
 
 from marktplaats.categories import L1Category, L2Category
-from marktplaats.config import ISSUE_LINK, HttpOptions
+from marktplaats.config import ISSUE_LINK
 from marktplaats.models import (
     Listing,
     ListingFirstImage,
@@ -166,9 +167,16 @@ class SearchQuery:
             "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
             "(KHTML, like Gecko) Chrome/101.0.0.0 Safari/537.36"
         ),
-        timeout: int = 15,
     ) -> None:
-        self.http_options = HttpOptions(user_agent=user_agent, timeout=timeout)
+        self._session = Session()
+        self._session.headers.update(
+            {
+                "User-Agent": user_agent,
+                "Accept": "application/json",
+                "Sec-Fetch-Mode": "cors",
+                "Sec-Fetch-Site": "same-origin",
+            }
+        )
 
         if not query and category is None:
             msg = (
@@ -220,7 +228,7 @@ class SearchQuery:
 
         self.response = get_request(
             "https://www.marktplaats.nl/lrp/api/search",
-            self.http_options,
+            self._session,
             params=params,
         )
 
@@ -287,7 +295,7 @@ class SearchQuery:
                 listing["title"],
                 listing["description"],
                 listing_time,
-                ListingSeller.parse(listing["sellerInformation"], self.http_options),
+                ListingSeller.parse(listing["sellerInformation"], self._session),
                 ListingLocation.parse(listing["location"]),
                 listing["priceInfo"]["priceCents"] / 100,
                 price_type,
@@ -296,7 +304,7 @@ class SearchQuery:
                 listing["categoryId"],
                 listing.get("attributes", []),
                 listing.get("extendedAttributes", []),
-                self.http_options,
+                self._session,
             )
             listings.append(listing_obj)
         return listings

--- a/src/marktplaats/utils.py
+++ b/src/marktplaats/utils.py
@@ -10,12 +10,10 @@ from requests import Response  # noqa: TID251 Not doing any requests
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from marktplaats.config import HttpOptions
+
 
 REQUEST_HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/101.0.0.0 Safari/537.36"
-    ),
     "Accept": "application/json",
     "Sec-Fetch-Mode": "cors",
     "Sec-Fetch-Site": "same-origin",
@@ -24,14 +22,18 @@ REQUEST_HEADERS = {
 
 def get_request(  # type: ignore[explicit-any] # This is Any to avoid replicating the actual type of the `params` parameter
     url: str,
+    http_options: HttpOptions,
     params: Mapping[str, Any] | None = None,
 ) -> Response:
     return requests.get(
         url,
         params=params,
         # Some headers to make the request look legit
-        headers=REQUEST_HEADERS,
-        timeout=15,
+        headers={
+            **REQUEST_HEADERS,
+            "User-Agent": http_options.user_agent,
+        },
+        timeout=http_options.timeout,
     )
 
 

--- a/src/marktplaats/utils.py
+++ b/src/marktplaats/utils.py
@@ -3,37 +3,22 @@ from __future__ import annotations
 from abc import ABC
 from typing import TYPE_CHECKING, Any
 
-import requests  # noqa: TID251 This is the only allowed use
-from requests import Response  # noqa: TID251 Not doing any requests
-
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from marktplaats.config import HttpOptions
-
-
-REQUEST_HEADERS = {
-    "Accept": "application/json",
-    "Sec-Fetch-Mode": "cors",
-    "Sec-Fetch-Site": "same-origin",
-}
+    from requests import Response, Session  # noqa: TID251 - Only used for type hinting.
 
 
 def get_request(  # type: ignore[explicit-any] # This is Any to avoid replicating the actual type of the `params` parameter
     url: str,
-    http_options: HttpOptions,
+    session: Session,
     params: Mapping[str, Any] | None = None,
 ) -> Response:
-    return requests.get(
+    return session.get(
         url,
         params=params,
-        # Some headers to make the request look legit
-        headers={
-            **REQUEST_HEADERS,
-            "User-Agent": http_options.user_agent,
-        },
-        timeout=http_options.timeout,
+        timeout=15,
     )
 
 

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import requests
 import responses
 
-from marktplaats.config import HttpOptions
 from marktplaats.models.listing_image import fetch_listing_images
 from tests.utils import get_mock_file
 
@@ -18,6 +18,6 @@ def test_parse_images() -> None:
         body=get_mock_file("image_response.html"),
     )
 
-    urls = fetch_listing_images("m123456789", HttpOptions("test-agent", 15))
+    urls = fetch_listing_images("m123456789", requests.Session())
     assert len(urls) == 9
     assert urls[0].startswith("https://images.marktplaats.com")

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import responses
 
+from marktplaats.config import HttpOptions
 from marktplaats.models.listing_image import fetch_listing_images
 from tests.utils import get_mock_file
 
@@ -17,6 +18,6 @@ def test_parse_images() -> None:
         body=get_mock_file("image_response.html"),
     )
 
-    urls = fetch_listing_images("m123456789")
+    urls = fetch_listing_images("m123456789", HttpOptions("test-agent", 15))
     assert len(urls) == 9
     assert urls[0].startswith("https://images.marktplaats.com")


### PR DESCRIPTION
The User-Agent string and request timeout were hardcoded, which made
detection of this library trivial. Both can now be configured, but
default to the previous hardcoded values, so no breaking changes are
introduced.
