### PR TITLE
feat: add support for 2dehands.be

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # marktplaats-py
-A small Python package to request listings from marktplaats.nl. It supports python 3.10+.
+A small Python package to request listings from marktplaats.nl or 2dehands.be. It supports python 3.10+.
 
 ## Installing
 ```shell
@@ -11,10 +11,11 @@ This is an example on how to use the library:
 ```py
 from datetime import datetime, timedelta
 
-from marktplaats import Condition, SearchQuery, SortBy, SortOrder, category_from_name
+from marktplaats import Condition, Platform, SearchQuery, SortBy, SortOrder, category_from_name
 
 search = SearchQuery(
     query="gazelle",  # Search query. Can be left out, but then category must be specified.
+    platform=Platform.MARKTPLAATS,  # Optional; MARKTPLAATS for .nl (default) or TWEEDEHANDS for .be
     zip_code="1016LV",  # Zip code to base distance from
     distance=100000,  # Max distance from the zip code for listings
     price_from=0,  # Lowest price to search for

--- a/src/marktplaats/__init__.py
+++ b/src/marktplaats/__init__.py
@@ -9,6 +9,7 @@ from marktplaats.categories import (
     get_l2_categories_by_parent as get_l2_categories_by_parent,
     get_subcategories as get_subcategories,
 )
+from marktplaats.enums import Platform as Platform
 from marktplaats.models import (
     Listing as Listing,
     ListingFirstImage as ListingFirstImage,

--- a/src/marktplaats/enums.py
+++ b/src/marktplaats/enums.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Platform(Enum):
+    """Enumeration of the different platforms marktplaats-py supports."""
+
+    MARKTPLAATS = "marktplaats.nl"
+    TWEEDEHANDS = "2dehands.be"

--- a/src/marktplaats/models/listing.py
+++ b/src/marktplaats/models/listing.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from types import NotImplementedType
 
     from marktplaats.api_types import Attribute
+    from marktplaats.enums import Platform
     from marktplaats.models.listing_location import ListingLocation
     from marktplaats.models.listing_seller import ListingSeller
     from marktplaats.models.price_type import PriceType
@@ -32,6 +33,7 @@ class Listing:
     category_id: int
     attributes: list[Attribute]
     extended_attributes: list[Attribute]
+    platform: Platform
 
     @property
     def images(self) -> list[ListingFirstImage]:
@@ -52,7 +54,7 @@ class Listing:
             return None
 
     def get_images(self) -> list[str]:
-        return fetch_listing_images(self.id)
+        return fetch_listing_images(self.id, self.platform)
 
     def __eq__(self, other: object) -> NotImplementedType | bool:
         if not isinstance(other, Listing):

--- a/src/marktplaats/models/listing_image.py
+++ b/src/marktplaats/models/listing_image.py
@@ -12,6 +12,7 @@ from marktplaats.utils import get_request
 
 if TYPE_CHECKING:
     from marktplaats.api_types import Picture
+    from marktplaats.enums import Platform
 
 
 @dataclass
@@ -42,15 +43,16 @@ class ListingFirstImage:
         ]
 
 
-def fetch_listing_images(listing_id: str) -> list[str]:
+def fetch_listing_images(listing_id: str, listing_platform: Platform) -> list[str]:
     """
     Return a list of image URLs for a given listing.
 
     It scrapes the listing page and parses the ld+json objects on that page.
     :param listing_id: The listing ID to get images for.
+    :param listing_platform: The platform the listing is on.
     :return: A list of image URLs (https).
     """  # noqa: DOC201 TODO: all the docstrings are a bit inconsistent
-    r = get_request(f"https://link.marktplaats.nl/{listing_id}")
+    r = get_request(f"https://link.{listing_platform.value}/{listing_id}")
     r.raise_for_status()  # raises so we can stop the fetching on a higher level
 
     soup = BeautifulSoup(r.text, "html.parser")

--- a/src/marktplaats/models/listing_seller.py
+++ b/src/marktplaats/models/listing_seller.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from typing_extensions import Self
@@ -11,6 +11,7 @@ from marktplaats.utils import get_request
 
 if TYPE_CHECKING:
     from marktplaats.api_types import Review, SellerInformation
+    from marktplaats.enums import Platform
 
 
 @dataclass
@@ -30,18 +31,20 @@ class ListingSeller:
     id: int
     name: str
     is_verified: bool
+    platform: Platform = field(repr=False)
 
     @classmethod
-    def parse(cls, data: SellerInformation) -> Self:
+    def parse(cls, data: SellerInformation, platform: Platform) -> Self:
         return cls(
             data["sellerId"],
             data["sellerName"],
             data["isVerified"],
+            platform,
         )
 
     def get_seller(self) -> Seller:
         request = get_request(
-            f"https://www.marktplaats.nl/v/api/seller-profile/{self.id}"
+            f"https://www.{self.platform.value}/v/api/seller-profile/{self.id}"
         )
 
         body = request.text

--- a/src/marktplaats/query.py
+++ b/src/marktplaats/query.py
@@ -12,6 +12,7 @@ from typing_extensions import NotRequired
 
 from marktplaats.categories import L1Category, L2Category
 from marktplaats.config import ISSUE_LINK
+from marktplaats.enums import Platform
 from marktplaats.models import (
     Listing,
     ListingFirstImage,
@@ -149,6 +150,7 @@ class SearchQuery:
         self,
         query: str = "",
         *,
+        platform: Platform = Platform.MARKTPLAATS,
         zip_code: str = "",
         distance: int = 1000000,  # in meters, basically unlimited
         price_from: int | None = None,
@@ -163,6 +165,8 @@ class SearchQuery:
         extra_attributes: Iterable[int]
         | None = None,  # EXPERIMENTAL: list of integers, just like Condition
     ) -> None:
+        self.platform = platform
+
         if not query and category is None:
             msg = (
                 "Invalid arguments: When the query is empty, "
@@ -212,7 +216,7 @@ class SearchQuery:
             params["l1CategoryId"] = str(category.id)
 
         self.response = get_request(
-            "https://www.marktplaats.nl/lrp/api/search",
+            f"https://www.{platform.value}/lrp/api/search",
             params=params,
         )
 
@@ -279,15 +283,16 @@ class SearchQuery:
                 listing["title"],
                 listing["description"],
                 listing_time,
-                ListingSeller.parse(listing["sellerInformation"]),
+                ListingSeller.parse(listing["sellerInformation"], self.platform),
                 ListingLocation.parse(listing["location"]),
                 listing["priceInfo"]["priceCents"] / 100,
                 price_type,
-                "https://link.marktplaats.nl/" + listing["itemId"],
+                f"https://link.{self.platform.value}/" + listing["itemId"],
                 ListingFirstImage.parse(listing.get("pictures")),
                 listing["categoryId"],
                 listing.get("attributes", []),
                 listing.get("extendedAttributes", []),
+                self.platform,
             )
             listings.append(listing_obj)
         return listings

--- a/tests/mock/image_response_2dehands.html
+++ b/tests/mock/image_response_2dehands.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+  <script type="application/ld+json">
+  {
+    "@context": "https:\u002F\u002Fschema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "2dehands",
+        "item": "https:\u002F\u002Fwww.2dehands.be\u002F"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "Computers en Software",
+        "item": "https:\u002F\u002Fwww.2dehands.be\u002Fl\u002Fcomputers-en-software\u002F"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "Moederborden",
+        "item": "https:\u002F\u002Fwww.2dehands.be\u002Fl\u002Fcomputers-en-software\u002Fmoederborden\u002F"
+      },
+      {
+        "@type": "ListItem",
+        "position": 4,
+        "name": "Raspberry Pi 4 Model B 2GB ram",
+        "item": "https:\u002F\u002Fwww.2dehands.be\u002Fv\u002Fcomputers-en-software\u002Fmoederborden\u002Fm2404214127-raspberry-pi-4-model-b-2gb-ram"
+      }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@type": "Product",
+    "@context": "https:\u002F\u002Fschema.org",
+    "name": "Raspberry Pi 4 Model B 2GB ram",
+    "description": "Raspberry Pi 4 Model B met 2GB RAM.Deze veelzijdige single-board computer is ideaal voor diverse projecten, zoals home automation, mediacenters, retro",
+    "offers": {
+      "@type": "Offer",
+      "url": "https:\u002F\u002Fwww.2dehands.be\u002Fv\u002Fcomputers-en-software\u002Fmoederborden\u002Fm2404214127-raspberry-pi-4-model-b-2gb-ram",
+      "priceCurrency": "EUR",
+      "price": "45",
+      "availability": "https:\u002F\u002Fschema.org\u002FInStock"
+    },
+    "image": [
+      "\u002F\u002Fimages.2dehands.com\u002Fapi\u002Fv1\u002Fhz-twh-pro-listing\u002Fimages\u002Fb63cc39e-9b4b-419d-ab35-1c407ffd428d?rule=ecg_mp_eps$_86",
+      "\u002F\u002Fimages.2dehands.com\u002Fapi\u002Fv1\u002Fhz-twh-pro-listing\u002Fimages\u002F4db16a1e-3eb6-4485-a297-cbc2d3c18c6e?rule=ecg_mp_eps$_86",
+      "\u002F\u002Fimages.2dehands.com\u002Fapi\u002Fv1\u002Fhz-twh-pro-listing\u002Fimages\u002F962b289c-502c-4871-8bac-2863bcd8b47d?rule=ecg_mp_eps$_86"
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  [
+    {
+      "@context": "https:\u002F\u002Fschema.org",
+      "@type": "ImageObject",
+      "creditText": "2dehands",
+      "name": "Raspberry Pi 4 Model B 2GB ram",
+      "description": "Raspberry Pi 4 Model B met 2GB RAM.Deze veelzijdige single-board computer is ideaal voor diverse projecten, zoals home automation, mediacenters, retro",
+      "contentUrl": "\u002F\u002Fimages.2dehands.com\u002Fapi\u002Fv1\u002Fhz-twh-pro-listing\u002Fimages\u002Fb63cc39e-9b4b-419d-ab35-1c407ffd428d?rule=ecg_mp_eps$_86",
+      "RepresentativeOfPage": true,
+      "creator": {
+        "@type": "Person",
+        "name": "Monopolygirl"
+      }
+    },
+    {
+      "@context": "https:\u002F\u002Fschema.org",
+      "@type": "ImageObject",
+      "creditText": "2dehands",
+      "name": "Raspberry Pi 4 Model B 2GB ram",
+      "description": "Raspberry Pi 4 Model B met 2GB RAM.Deze veelzijdige single-board computer is ideaal voor diverse projecten, zoals home automation, mediacenters, retro",
+      "contentUrl": "\u002F\u002Fimages.2dehands.com\u002Fapi\u002Fv1\u002Fhz-twh-pro-listing\u002Fimages\u002F4db16a1e-3eb6-4485-a297-cbc2d3c18c6e?rule=ecg_mp_eps$_86",
+      "RepresentativeOfPage": false,
+      "creator": {
+        "@type": "Person",
+        "name": "Monopolygirl"
+      }
+    },
+    {
+      "@context": "https:\u002F\u002Fschema.org",
+      "@type": "ImageObject",
+      "creditText": "2dehands",
+      "name": "Raspberry Pi 4 Model B 2GB ram",
+      "description": "Raspberry Pi 4 Model B met 2GB RAM.Deze veelzijdige single-board computer is ideaal voor diverse projecten, zoals home automation, mediacenters, retro",
+      "contentUrl": "\u002F\u002Fimages.2dehands.com\u002Fapi\u002Fv1\u002Fhz-twh-pro-listing\u002Fimages\u002F962b289c-502c-4871-8bac-2863bcd8b47d?rule=ecg_mp_eps$_86",
+      "RepresentativeOfPage": false,
+      "creator": {
+        "@type": "Person",
+        "name": "Monopolygirl"
+      }
+    }
+  ]
+  </script>
+</body>
+</html>

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import responses
 
+from marktplaats.enums import Platform
 from marktplaats.models.listing_image import fetch_listing_images
 from tests.utils import get_mock_file
 
@@ -17,6 +18,6 @@ def test_parse_images() -> None:
         body=get_mock_file("image_response.html"),
     )
 
-    urls = fetch_listing_images("m123456789")
+    urls = fetch_listing_images("m123456789", Platform.MARKTPLAATS)
     assert len(urls) == 9
     assert urls[0].startswith("https://images.marktplaats.com")

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -21,3 +21,16 @@ def test_parse_images() -> None:
     urls = fetch_listing_images("m123456789", Platform.MARKTPLAATS)
     assert len(urls) == 9
     assert urls[0].startswith("https://images.marktplaats.com")
+
+
+@responses.activate
+def test_parse_images_2dehands() -> None:
+    responses.get(
+        "https://link.2dehands.be/m2404214127",
+        status=200,
+        body=get_mock_file("image_response_2dehands.html"),
+    )
+
+    urls = fetch_listing_images("m2404214127", Platform.TWEEDEHANDS)
+    assert len(urls) == 3
+    assert urls[0].startswith("https://images.2dehands.com")

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -7,6 +7,7 @@ from marktplaats import (
     ListingFirstImage,
     ListingLocation,
     ListingSeller,
+    Platform,
     PriceType,
     SearchQuery,
     SortBy,
@@ -17,7 +18,7 @@ from marktplaats.models.listing_seller import Seller
 
 
 """
-Live tests (sent to Marktplaats) to ensure they
+Live tests (sent to Marktplaats and 2dehands) to ensure they
 haven't deployed breaking changes.
 """
 
@@ -102,6 +103,41 @@ def test_request_with_condition() -> None:
     search = SearchQuery(
         "schijf",
         zip_code="1016LV",
+        distance=100000,
+        price_from=0,
+        price_to=100,
+        offered_since=datetime.now() - timedelta(days=7),
+        condition=Condition.NOT_WORKING,
+        category=category_from_name("Computers en Software"),
+    )
+
+    _validate_response(search)
+
+
+def test_request_2dehands() -> None:
+    search = SearchQuery(
+        "fiets",
+        platform=Platform.TWEEDEHANDS,
+        zip_code="1000",
+        distance=100000,
+        price_from=0,
+        price_to=100,
+        limit=5,
+        offset=0,
+        sort_by=SortBy.LOCATION,
+        sort_order=SortOrder.ASC,
+        offered_since=datetime.now() - timedelta(days=7),
+        category=category_from_name("Fietsen en Brommers"),
+    )
+
+    _validate_response(search, check_time=True)
+
+
+def test_request_with_condition_2dehands() -> None:
+    search = SearchQuery(
+        "schijf",
+        platform=Platform.TWEEDEHANDS,
+        zip_code="1000",
         distance=100000,
         price_from=0,
         price_to=100,


### PR DESCRIPTION
Marktplaats.nl and 2dehands.be are both owned by Adevinta. They are separate websites with different listings, but their frontend and backend are almost identical.

This PR adds support for 2dehands. The Dutch platform Marktplaats remains the default, so no breaking changes are introduced.

As far as I can tell, search queries on 2dehands work perfectly fine. The only minor issue is that some categories have different names depending on the platform. For example, category ID 1152 is called "Vacatures | Horeca en Catering" on Marktplaats, while it is called "Vacatures | Horeca en Traiteur" on 2dehands. When searching with `category=category_from_name()`, only the Dutch category names can currently be used, as those are the ones stored in `l*_categories.json`.