### PR TITLE
fix: respect the requested limit in get_listings()

### DIFF
--- a/src/marktplaats/query.py
+++ b/src/marktplaats/query.py
@@ -218,6 +218,9 @@ class SearchQuery:
                 f"offeredSince:{int(offered_since.timestamp()) * 1000}",
             ]
 
+        # Kept around because the API can return more listings than requested
+        self.limit = limit
+
         if category:
             # If it is an L2 category
             if isinstance(category, L2Category):
@@ -260,7 +263,10 @@ class SearchQuery:
 
     def get_listings(self) -> list[Listing]:
         listings = []
-        for listing in self.body_json["listings"]:
+        # Marktplaats pads small pages with extra listings (e.g. a limit=5
+        #  request returns 20). The first `limit` items are the actual page
+        #  window, so anything after that is cut off.
+        for listing in self.body_json["listings"][: self.limit]:
             try:
                 listing_time = parse_date(listing["date"])
             except ValueError:

--- a/src/marktplaats/query.py
+++ b/src/marktplaats/query.py
@@ -264,7 +264,7 @@ class SearchQuery:
     def get_listings(self) -> list[Listing]:
         listings = []
         # Marktplaats pads small pages with extra listings (e.g. a limit=5
-        #  request returns 20). The first `limit` items are the actual page
+        #  request sometimes returns 20). The first `limit` items are the actual page
         #  window, so anything after that is cut off.
         for listing in self.body_json["listings"][: self.limit]:
             try:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import date, datetime
 
 import pytest
@@ -180,3 +181,22 @@ def test_query_category_valueerror() -> None:
         match=r"^Invalid arguments: When the query is empty, a category must be specified.$",
     ):
         _query = SearchQuery(price_to=10)
+
+
+@responses.activate
+def test_listing_limit_is_respected() -> None:
+    # Marktplaats pads small pages: a limit=5 request comes back
+    #  with about 20 listings. Only the requested amount should
+    #  make it out of get_listings().
+    body = json.loads(get_mock_file("query_response.json"))
+    body["listings"] *= 20
+
+    responses.get(
+        "https://www.marktplaats.nl/lrp/api/search",
+        status=200,
+        body=json.dumps(body),
+    )
+
+    query = SearchQuery("fiets", limit=5)
+
+    assert len(query.get_listings()) == 5


### PR DESCRIPTION
Marktplaats started padding small pages with extra listings, so `get_listings()` returns more items than you asked for:

```python
>>> len(SearchQuery("fiets", limit=5).get_listings())
20
```

limit=1 gives 16, limit=10 gives 25, and from limit=30 on it is exact again. I checked the paging behaviour against a limit=10 request: the first `limit` items are the real page window (an offset=5 page lines up with items 5-9), and the padding after that does not line up with the next page. So this slices `get_listings()` to the requested limit. Regression test included.