### PR TITLE
fix: remove placeholder images from `.get_images()` result

### DIFF
--- a/src/marktplaats/models/listing_image.py
+++ b/src/marktplaats/models/listing_image.py
@@ -62,9 +62,13 @@ def fetch_listing_images(listing_id: str) -> list[str]:
         parsed = json.loads(data.text)
         # the list of image URLs is hidden within the product object
         if type(parsed) is dict and parsed["@type"] == "Product":
-            # the returned images are in a format that don't include a scheme,
-            #  so we add one manually
-            images.extend(f"https:{image}" for image in parsed["image"])
+            # actual photos are protocol-relative (//images.marktplaats.com/...),
+            #  but the placeholder image on listings without photos
+            #  already comes with a scheme
+            images.extend(
+                f"https:{image}" if image.startswith("//") else image
+                for image in parsed["image"]
+            )
             break
 
     return images

--- a/src/marktplaats/models/listing_image.py
+++ b/src/marktplaats/models/listing_image.py
@@ -67,9 +67,7 @@ def fetch_listing_images(listing_id: str) -> list[str]:
             #  Listings without photos have an absolute placeholder URL here
             #  instead, which we don't want to return as an image.
             images.extend(
-                f"https:{image}"
-                for image in parsed["image"]
-                if image.startswith("//")
+                f"https:{image}" for image in parsed["image"] if image.startswith("//")
             )
             break
 

--- a/src/marktplaats/models/listing_image.py
+++ b/src/marktplaats/models/listing_image.py
@@ -47,6 +47,7 @@ def fetch_listing_images(listing_id: str) -> list[str]:
     Return a list of image URLs for a given listing.
 
     It scrapes the listing page and parses the ld+json objects on that page.
+    Returns an empty list if the listing has no photos.
     :param listing_id: The listing ID to get images for.
     :return: A list of image URLs (https).
     """  # noqa: DOC201 TODO: all the docstrings are a bit inconsistent
@@ -62,12 +63,13 @@ def fetch_listing_images(listing_id: str) -> list[str]:
         parsed = json.loads(data.text)
         # the list of image URLs is hidden within the product object
         if type(parsed) is dict and parsed["@type"] == "Product":
-            # actual photos are protocol-relative (//images.marktplaats.com/...),
-            #  but the placeholder image on listings without photos
-            #  already comes with a scheme
+            # actual photos are protocol-relative (//images.marktplaats.com/...).
+            #  Listings without photos have an absolute placeholder URL here
+            #  instead, which we don't want to return as an image.
             images.extend(
-                f"https:{image}" if image.startswith("//") else image
+                f"https:{image}"
                 for image in parsed["image"]
+                if image.startswith("//")
             )
             break
 

--- a/tests/mock/image_response_no_photos.html
+++ b/tests/mock/image_response_no_photos.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Gezocht: hulp bij verhuizen","image":["https://www.hzcdn.io/bff/static/vendor/hz-web-ui/mp/assets/tenant-coin--nlnl.e0064ede.svg"]}</script>
+</head>
+<body></body>
+</html>

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -23,10 +23,10 @@ def test_parse_images() -> None:
 
 
 @responses.activate
-def test_absolute_image_urls_are_not_mangled() -> None:
-    # Listings without photos have a placeholder image in their
-    #  ld+json data. That one already includes a scheme, so it
-    #  shouldn't get another "https:" glued in front of it.
+def test_no_photos_returns_empty_list() -> None:
+    # Listings without photos have an absolute placeholder URL in
+    #  their ld+json data instead of the usual protocol-relative
+    #  photo URLs. That placeholder is not a real image.
     responses.get(
         "https://link.marktplaats.nl/m2404914283",
         status=200,
@@ -34,6 +34,4 @@ def test_absolute_image_urls_are_not_mangled() -> None:
     )
 
     urls = fetch_listing_images("m2404914283")
-    assert urls == [
-        "https://www.hzcdn.io/bff/static/vendor/hz-web-ui/mp/assets/tenant-coin--nlnl.e0064ede.svg",
-    ]
+    assert urls == []

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -20,3 +20,20 @@ def test_parse_images() -> None:
     urls = fetch_listing_images("m123456789")
     assert len(urls) == 9
     assert urls[0].startswith("https://images.marktplaats.com")
+
+
+@responses.activate
+def test_absolute_image_urls_are_not_mangled() -> None:
+    # Listings without photos have a placeholder image in their
+    #  ld+json data. That one already includes a scheme, so it
+    #  shouldn't get another "https:" glued in front of it.
+    responses.get(
+        "https://link.marktplaats.nl/m2404914283",
+        status=200,
+        body=get_mock_file("image_response_no_photos.html"),
+    )
+
+    urls = fetch_listing_images("m2404914283")
+    assert urls == [
+        "https://www.hzcdn.io/bff/static/vendor/hz-web-ui/mp/assets/tenant-coin--nlnl.e0064ede.svg",
+    ]


### PR DESCRIPTION
`get_images()` on a listing without photos returns a broken URL:

```python
>>> listing.get_images()
['https:https://www.hzcdn.io/bff/static/vendor/hz-web-ui/mp/assets/tenant-coin--nlnl.e0064ede.svg']
```

Real photos in the ld+json are protocol-relative (`//images.marktplaats.com/...`), but the placeholder on photo-less listings already comes with a scheme. Now the `https:` prefix is only added when the URL actually starts with `//`.

Side note: this still returns the placeholder icon for listings without photos. If you would rather have an empty list there, happy to change it.