### PR TITLE
Revert "feat: make user agent configurable (#189)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ search = SearchQuery(
     condition=Condition.NEW,  # NEW, AS_GOOD_AS_NEW, USED or category-specific
     offered_since=datetime.now() - timedelta(days=7),  # Filter listings since a point in time
     category=category_from_name("Fietsen en Brommers"),  # Filter in specific category (L1) or subcategory (L2)
-    user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 ...",  # Optional; identify your app
 )
 
 listings = search.get_listings()

--- a/src/marktplaats/models/listing.py
+++ b/src/marktplaats/models/listing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from marktplaats.models.listing_image import ListingFirstImage, fetch_listing_images
@@ -10,8 +10,6 @@ from marktplaats.models.listing_image import ListingFirstImage, fetch_listing_im
 if TYPE_CHECKING:
     from datetime import date
     from types import NotImplementedType
-
-    from requests import Session  # noqa: TID251 - Only used for type hinting.
 
     from marktplaats.api_types import Attribute
     from marktplaats.models.listing_location import ListingLocation
@@ -34,7 +32,6 @@ class Listing:
     category_id: int
     attributes: list[Attribute]
     extended_attributes: list[Attribute]
-    _session: Session = field(repr=False)
 
     @property
     def images(self) -> list[ListingFirstImage]:
@@ -55,7 +52,7 @@ class Listing:
             return None
 
     def get_images(self) -> list[str]:
-        return fetch_listing_images(self.id, self._session)
+        return fetch_listing_images(self.id)
 
     def __eq__(self, other: object) -> NotImplementedType | bool:
         if not isinstance(other, Listing):

--- a/src/marktplaats/models/listing_image.py
+++ b/src/marktplaats/models/listing_image.py
@@ -11,8 +11,6 @@ from marktplaats.utils import get_request
 
 
 if TYPE_CHECKING:
-    from requests import Session  # noqa: TID251 - Only used for type hinting.
-
     from marktplaats.api_types import Picture
 
 
@@ -44,7 +42,7 @@ class ListingFirstImage:
         ]
 
 
-def fetch_listing_images(listing_id: str, session: Session) -> list[str]:
+def fetch_listing_images(listing_id: str) -> list[str]:
     """
     Return a list of image URLs for a given listing.
 
@@ -53,7 +51,7 @@ def fetch_listing_images(listing_id: str, session: Session) -> list[str]:
     :param listing_id: The listing ID to get images for.
     :return: A list of image URLs (https).
     """  # noqa: DOC201 TODO: all the docstrings are a bit inconsistent
-    r = get_request(f"https://link.marktplaats.nl/{listing_id}", session)
+    r = get_request(f"https://link.marktplaats.nl/{listing_id}")
     r.raise_for_status()  # raises so we can stop the fetching on a higher level
 
     soup = BeautifulSoup(r.text, "html.parser")

--- a/src/marktplaats/models/listing_seller.py
+++ b/src/marktplaats/models/listing_seller.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from typing_extensions import Self
@@ -10,8 +10,6 @@ from marktplaats.utils import get_request
 
 
 if TYPE_CHECKING:
-    from requests import Session  # noqa: TID251 - Only used for type hinting.
-
     from marktplaats.api_types import Review, SellerInformation
 
 
@@ -32,21 +30,18 @@ class ListingSeller:
     id: int
     name: str
     is_verified: bool
-    _session: Session = field(repr=False, compare=False)
 
     @classmethod
-    def parse(cls, data: SellerInformation, session: Session) -> Self:
+    def parse(cls, data: SellerInformation) -> Self:
         return cls(
             data["sellerId"],
             data["sellerName"],
             data["isVerified"],
-            session,
         )
 
     def get_seller(self) -> Seller:
         request = get_request(
-            f"https://www.marktplaats.nl/v/api/seller-profile/{self.id}",
-            self._session,
+            f"https://www.marktplaats.nl/v/api/seller-profile/{self.id}"
         )
 
         body = request.text

--- a/src/marktplaats/query.py
+++ b/src/marktplaats/query.py
@@ -6,7 +6,6 @@ from datetime import date, datetime, timedelta
 from enum import Enum
 from typing import TYPE_CHECKING, TypedDict
 
-from requests import Session  # noqa: TID251 - Constructing a session.
 from requests.exceptions import (  # noqa: TID251 Not doing any requests
     JSONDecodeError as requests_JSONDecodeError,
 )
@@ -165,21 +164,7 @@ class SearchQuery:
         category: L1Category | L2Category | None = None,
         extra_attributes: Iterable[int]
         | None = None,  # EXPERIMENTAL: list of integers, just like Condition
-        user_agent: str = (
-            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-            "(KHTML, like Gecko) Chrome/101.0.0.0 Safari/537.36"
-        ),
     ) -> None:
-        self._session = Session()
-        self._session.headers.update(
-            {
-                "User-Agent": user_agent,
-                "Accept": "application/json",
-                "Sec-Fetch-Mode": "cors",
-                "Sec-Fetch-Site": "same-origin",
-            }
-        )
-
         if not query and category is None:
             msg = (
                 "Invalid arguments: When the query is empty, "
@@ -244,7 +229,6 @@ class SearchQuery:
 
         self.response = get_request(
             "https://www.marktplaats.nl/lrp/api/search",
-            self._session,
             params=params,
         )
 
@@ -311,7 +295,7 @@ class SearchQuery:
                 listing["title"],
                 listing["description"],
                 listing_time,
-                ListingSeller.parse(listing["sellerInformation"], self._session),
+                ListingSeller.parse(listing["sellerInformation"]),
                 ListingLocation.parse(listing["location"]),
                 listing["priceInfo"]["priceCents"] / 100,
                 price_type,
@@ -320,7 +304,6 @@ class SearchQuery:
                 listing["categoryId"],
                 listing.get("attributes", []),
                 listing.get("extendedAttributes", []),
-                self._session,
             )
             listings.append(listing_obj)
         return listings

--- a/src/marktplaats/utils.py
+++ b/src/marktplaats/utils.py
@@ -3,21 +3,34 @@ from __future__ import annotations
 from abc import ABC
 from typing import TYPE_CHECKING, Any
 
+import requests  # noqa: TID251 This is the only allowed use
+from requests import Response  # noqa: TID251 Not doing any requests
+
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from requests import Response, Session  # noqa: TID251 - Only used for type hinting.
+
+REQUEST_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/101.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/json",
+    "Sec-Fetch-Mode": "cors",
+    "Sec-Fetch-Site": "same-origin",
+}
 
 
 def get_request(  # type: ignore[explicit-any] # This is Any to avoid replicating the actual type of the `params` parameter
     url: str,
-    session: Session,
     params: Mapping[str, Any] | None = None,
 ) -> Response:
-    return session.get(
+    return requests.get(
         url,
         params=params,
+        # Some headers to make the request look legit
+        headers=REQUEST_HEADERS,
         timeout=15,
     )
 

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import requests
 import responses
 
 from marktplaats.models.listing_image import fetch_listing_images
@@ -18,7 +17,7 @@ def test_parse_images() -> None:
         body=get_mock_file("image_response.html"),
     )
 
-    urls = fetch_listing_images("m123456789", requests.Session())
+    urls = fetch_listing_images("m123456789")
     assert len(urls) == 9
     assert urls[0].startswith("https://images.marktplaats.com")
 


### PR DESCRIPTION
This reverts commit a9bea62b3c592386697862712226e78982bfcb34.
Caused a soft conflict with 28bc0dc and e63a48c.

@qadzek Sorry, I should have noticed this. Could you open a new PR and fix the conflicts? They're not trivial (how to deal with `SellerQuery`?)