### PR TITLE
fix: fix fetching listing images when images are absolute URLs

### DIFF
--- a/src/marktplaats/models/listing_image.py
+++ b/src/marktplaats/models/listing_image.py
@@ -62,13 +62,18 @@ def fetch_listing_images(listing_id: str) -> list[str]:
     for data in soup.select('script[type="application/ld+json"]'):
         parsed = json.loads(data.text)
         # the list of image URLs is hidden within the product object
-        if type(parsed) is dict and parsed["@type"] == "Product":
-            # actual photos are protocol-relative (//images.marktplaats.com/...).
-            #  Listings without photos have an absolute placeholder URL here
-            #  instead, which we don't want to return as an image.
-            images.extend(
-                f"https:{image}" for image in parsed["image"] if image.startswith("//")
-            )
+        if isinstance(parsed, dict) and parsed["@type"] == "Product":
+            #  Listings without photos have an absolute placeholder URL,
+            #  which we don't want to return as an image. The URL is/was:
+            #  https://www.hzcdn.io/bff/static/vendor/hz-web-ui/mp/assets/tenant-coin--nlnl.e0064ede.svg
+            for image in parsed["image"]:
+                if image.startswith("//"):
+                    # Sometimes photos are protocol-relative
+                    #  (//images.marktplaats.com/...)
+                    images.append(f"https:{image}")
+                elif image.startswith("https://images.marktplaats.com"):
+                    images.append(image)
+
             break
 
     return images


### PR DESCRIPTION
Ref #213, combined the old with the new behavior. It is unclear to me if it is permanently changed (back?) or if both can still occur, but there's no harm in supporting both in any case.

Closes #228

@jensjeflensje please merge so I stop getting daily emails about the tests failing :pleading_face:
Also please review if the comments read ok like this